### PR TITLE
trans errClosing into io.EOF to fix this expected error.

### DIFF
--- a/service/buffer.go
+++ b/service/buffer.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"sync"
 	"sync/atomic"
+	"net"
 )
 
 var (
@@ -162,6 +163,12 @@ func (this *buffer) ReadFrom(r io.Reader) (int64, error) {
 			}
 		}
 
+		if opError, ok := err.(*net.OpError); ok {
+			if opError.Err.Error() == "use of closed network connection" {
+				return total, io.EOF
+			}
+		}
+		
 		if err != nil {
 			return total, err
 		}


### PR DESCRIPTION
this will work with sendrecv.go, func receiver:
`_, err := this.in.ReadFrom(r)

			if err != nil {
				if err != io.EOF {
					glog.Errorf("(%s) error reading from connection: %v", this.cid(), err)
				}
				return
			}`
avoid print error like this:
`sendrecv.go:75/receiver] (1/surgemq1) error reading from connection: read tcp 127.0.0.1:49192->127.0.0.1:1883: use of closed network connection`
