### PR TITLE
Fix issue that to close a connection when receive a PINGRESP message

### DIFF
--- a/sessions/ackqueue.go
+++ b/sessions/ackqueue.go
@@ -171,6 +171,7 @@ func (this *Ackqueue) Ack(msg message.Message) error {
 			if err != nil {
 				return err
 			}
+			this.ping.Ackbuf = this.ping.Msgbuf
 		}
 
 	default:

--- a/sessions/ackqueue.go
+++ b/sessions/ackqueue.go
@@ -164,7 +164,13 @@ func (this *Ackqueue) Ack(msg message.Message) error {
 
 	case message.PINGRESP:
 		if this.ping.Mtype == message.PINGREQ {
+			this.ping.Mtype = message.PINGRESP
 			this.ping.State = message.PINGRESP
+			this.ping.Msgbuf = make([]byte, msg.Len())
+			_, err := msg.Encode(this.ping.Msgbuf)
+			if err != nil {
+				return err
+			}
 		}
 
 	default:


### PR DESCRIPTION
refs #27 

When `service.Client` receive a PINGRESP message, client disconnect with panic in `service.process()`.
Because several members of `Ackqueue.ping` are nil.